### PR TITLE
fixed variables usage, added creation of ubuntu server on private subnet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,12 +2,12 @@
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 
-# s3 backend details
+# s3 backend details needed for initialization
 TFSTATE_BUCKET=
 TFSTATE_BUCKET_KEY=
 TFSTATE_DBTABLE=
+TF_VAR_region=
 
 # other tf vars: uncomment and override as necessary
 # TF_VAR_prefix=
 # TF_VAR_project=
-# TF_VAR_region=

--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,9 @@ AWS_SECRET_ACCESS_KEY=
 TFSTATE_BUCKET=
 TFSTATE_BUCKET_KEY=
 TFSTATE_DBTABLE=
-TF_VAR_region=
 
 # other tf vars: uncomment and override as necessary
+TF_VAR_region=
+TF_VAR_bastion_keyname=
 # TF_VAR_prefix=
 # TF_VAR_project=

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,12 @@ tf.init:
 	-backend-config="dynamodb_table=${TFSTATE_DYNAMODB}" \
 	-backend-config="region=${TF_VAR_region}" 
 
+tf.init.migrate:
+	terraform -chdir=terraform init -migrate-state -backend-config="bucket=${TFSTATE_BUCKET}" \
+	-backend-config="key=${TFSTATE_BUCKET_KEY}" \
+	-backend-config="dynamodb_table=${TFSTATE_DYNAMODB}" \
+	-backend-config="region=${TF_VAR_region}" 
+
 tf.validate:
 	terraform -chdir=terraform validate
 	

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
-# caveat: env keys without `$` chars presumed.
+# caveat: env keys without `$` chars presumed. Note: Make interprets '#' as start of comment for itself, so escape as `\#`whenever needed for shell script fragments. 
 include .env
-export $(shell sed 's/=.*//' .env)
+export $(shell grep -v '^\#' .env | sed 's/=.*//')
 
 # use the backend config file because variables are not allowed in backend block
 tf.init:

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -23,3 +23,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:fbd78c63eb69982573631912bcb9eeed63eee32d3c7087a076af8f3d9e8c60cd",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/http" {
+  version = "3.4.0"
+  hashes = [
+    "h1:h3URn6qAnP36OlSqI1tTuKgPL3GriZaJia9ZDrUvRdg=",
+    "zh:56712497a87bc4e91bbaf1a5a2be4b3f9cfa2384baeb20fc9fad0aff8f063914",
+    "zh:6661355e1090ebacab16a40ede35b029caffc279d67da73a000b6eecf0b58eba",
+    "zh:67b92d343e808b92d7e6c3bbcb9b9d5475fecfed0836963f7feb9d9908bd4c4f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:86ebb9be9b685c96dbb5c024b55d87526d57a4b127796d6046344f8294d3f28e",
+    "zh:902be7cfca4308cba3e1e7ba6fc292629dfd150eb9a9f054a854fa1532b0ceba",
+    "zh:9ba26e0215cd53b21fe26a0a98c007de1348b7d13a75ae3cfaf7729e0f2c50bb",
+    "zh:a195c941e1f1526147134c257ff549bea4c89c953685acd3d48d9de7a38f39dc",
+    "zh:a7967b3d2a8c3e7e1dc9ae381ca753268f9fce756466fe2fc9e414ca2d85a92e",
+    "zh:bde56542e9a093434d96bea21c341285737c6d38fea2f05e12ba7b333f3e9c05",
+    "zh:c0306f76903024c497fd01f9fd9bace5854c263e87a97bc2e89dcc96d35ca3cc",
+    "zh:f9335a6c336171e85f8e3e99c3d31758811a19aeb21fa8c9013d427e155ae2a9",
+  ]
+}

--- a/terraform/bastion.tf
+++ b/terraform/bastion.tf
@@ -34,7 +34,6 @@ resource "aws_security_group" "bastion" {
 
 
 resource "aws_eip" "bastion" {
-  # this ip exists inside a vpc
   domain     = "vpc"
   depends_on = [aws_internet_gateway.main]
 
@@ -48,7 +47,6 @@ resource "aws_instance" "bastion" {
   ami           = data.aws_ami.amazon_linux.id
   instance_type = "t2.nano"
 
-  # iam_instance_profile = aws_iam_instance_profile.bastion.name
   key_name  = var.bastion_keyname
   subnet_id = aws_subnet.public_a.id
   vpc_security_group_ids = [
@@ -61,7 +59,6 @@ resource "aws_instance" "bastion" {
   )
 }
 
-# assign ip addr
 resource "aws_eip_association" "eip_assoc" {
   instance_id   = aws_instance.bastion.id
   allocation_id = aws_eip.bastion.id

--- a/terraform/bastion.tf
+++ b/terraform/bastion.tf
@@ -7,15 +7,6 @@ data "aws_ami" "amazon_linux" {
   owners = ["amazon"]
 }
 
-# Policy that lets the EC2 service itself sts:AssumeRole, in order to set up the bastion with the right instance role, via aws_iam_policy_document
-# (not used)
-
-# Create and attach any other policies to the target role, via aws_iam_role_policy_attachment here:
-# (not used)
-
-# Create the instance profile via aws_iam_instance_profile (attached in aws_instance)
-# (not used)
-
 resource "aws_security_group" "bastion" {
   description = "control bastion network traffic"
   vpc_id      = aws_vpc.main.id
@@ -29,10 +20,9 @@ resource "aws_security_group" "bastion" {
   }
 
   egress {
-    protocol  = "tcp"
-    from_port = 22
-    to_port   = 22
-    # cidr_blocks = ["${local.own_ip}/32", "18.206.107.24/29"]
+    protocol    = "tcp"
+    from_port   = 22
+    to_port     = 22
     cidr_blocks = ["0.0.0.0/0"]
   }
 

--- a/terraform/bastion.tf
+++ b/terraform/bastion.tf
@@ -29,10 +29,11 @@ resource "aws_security_group" "bastion" {
   }
 
   egress {
-    protocol    = "tcp"
-    from_port   = 22
-    to_port     = 22
-    cidr_blocks = ["${local.own_ip}/32", "18.206.107.24/29"]
+    protocol  = "tcp"
+    from_port = 22
+    to_port   = 22
+    # cidr_blocks = ["${local.own_ip}/32", "18.206.107.24/29"]
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   tags = merge(

--- a/terraform/bastion.tf
+++ b/terraform/bastion.tf
@@ -1,0 +1,77 @@
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-2.0.*-x86_64-gp2"]
+  }
+  owners = ["amazon"]
+}
+
+# Policy that lets the EC2 service itself sts:AssumeRole, in order to set up the bastion with the right instance role, via aws_iam_policy_document
+# (not used)
+
+# Create and attach any other policies to the target role, via aws_iam_role_policy_attachment here:
+# (not used)
+
+# Create the instance profile via aws_iam_instance_profile (attached in aws_instance)
+# (not used)
+
+resource "aws_security_group" "bastion" {
+  description = "control bastion network traffic"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol  = "tcp"
+    from_port = 22
+    to_port   = 22
+    # second cidr is requisite AWS ip ranges used for browser-based SSH connections (at last check)
+    cidr_blocks = ["${local.own_ip}/32", "18.206.107.24/29"]
+  }
+
+  egress {
+    protocol    = "tcp"
+    from_port   = 22
+    to_port     = 22
+    cidr_blocks = ["${local.own_ip}/32", "18.206.107.24/29"]
+  }
+
+  tags = merge(
+    local.common_tags,
+    { "Name" = "${local.prefix}-bastion" }
+  )
+}
+
+
+resource "aws_eip" "bastion" {
+  # this ip exists inside a vpc
+  domain     = "vpc"
+  depends_on = [aws_internet_gateway.main]
+
+  tags = merge(
+    local.common_tags,
+    { "Name" = "${local.prefix}-bastion" }
+  )
+}
+
+resource "aws_instance" "bastion" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t2.nano"
+
+  # iam_instance_profile = aws_iam_instance_profile.bastion.name
+  key_name  = var.bastion_keyname
+  subnet_id = aws_subnet.public_a.id
+  vpc_security_group_ids = [
+    aws_security_group.bastion.id
+  ]
+
+  tags = merge(
+    local.common_tags,
+    { "Name" = "${local.prefix}-bastion" }
+  )
+}
+
+# assign ip addr
+resource "aws_eip_association" "eip_assoc" {
+  instance_id   = aws_instance.bastion.id
+  allocation_id = aws_eip.bastion.id
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -18,7 +18,9 @@ provider "aws" {
 }
 
 locals {
-  prefix = var.prefix
+  prefix  = var.prefix
+  project = var.project
+  region  = var.region
 
   common_tags = {
     Project   = var.project

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -17,10 +17,17 @@ provider "aws" {
   region = var.region
 }
 
+# for constraining access to own ip
+data "http" "ip" {
+  url = "https://ifconfig.me/ip"
+}
+
 locals {
   prefix  = var.prefix
   project = var.project
   region  = var.region
+  pubkey  = var.bastion_keyname
+  own_ip  = data.http.ip.response_body
 
   common_tags = {
     Project   = var.project

--- a/terraform/priv-server-a.tf
+++ b/terraform/priv-server-a.tf
@@ -1,0 +1,71 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  # from terraform docs example lookup
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical (ubuntu)
+}
+
+
+# firewall
+resource "aws_security_group" "allow_ssh" {
+  name        = "allow_ssh"
+  description = "Allow ssh inbound traffic"
+  vpc_id      = aws_vpc.main.id
+
+  # allow from public_a only
+  ingress {
+    description = "SSH from VPC public subnets"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [aws_subnet.private_a.cidr_block]
+  }
+
+  egress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [aws_subnet.private_a.cidr_block]
+  }
+
+  tags = merge(
+    local.common_tags,
+    { "Name" = "${local.prefix}-allow-ssh-a" }
+  )
+}
+
+resource "aws_network_interface" "ubuntu-nic-a" {
+  subnet_id       = aws_subnet.private_a.id
+  security_groups = [aws_security_group.allow_ssh.id]
+
+  tags = merge(
+    local.common_tags,
+    { "Name" = "${local.prefix}-ubuntu-nic-a" }
+  )
+}
+
+resource "aws_instance" "ubuntu-a" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t2.micro"
+
+  network_interface {
+    network_interface_id = aws_network_interface.ubuntu-nic-a.id
+    device_index         = 0
+  }
+
+  tags = merge(
+    local.common_tags,
+    { "Name" = "${local.prefix}-ubuntu-a" }
+  )
+}

--- a/terraform/priv-server-a.tf
+++ b/terraform/priv-server-a.tf
@@ -58,6 +58,7 @@ resource "aws_network_interface" "ubuntu-nic-a" {
 resource "aws_instance" "ubuntu-a" {
   ami           = data.aws_ami.ubuntu.id
   instance_type = "t2.micro"
+  key_name      = local.pubkey
 
   network_interface {
     network_interface_id = aws_network_interface.ubuntu-nic-a.id

--- a/terraform/priv-server-a.tf
+++ b/terraform/priv-server-a.tf
@@ -29,14 +29,15 @@ resource "aws_security_group" "allow_ssh" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = [aws_subnet.private_a.cidr_block]
+    # cidr_blocks = [aws_subnet.private_a.cidr_block]
+    cidr_blocks = [aws_vpc.main.cidr_block]
   }
 
   egress {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = [aws_subnet.private_a.cidr_block]
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   tags = merge(

--- a/terraform/priv-server-a.tf
+++ b/terraform/priv-server-a.tf
@@ -29,7 +29,6 @@ resource "aws_security_group" "allow_ssh" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    # cidr_blocks = [aws_subnet.private_a.cidr_block]
     cidr_blocks = [aws_vpc.main.cidr_block]
   }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,3 +15,9 @@ variable "region" {
   default  = "us-east-1"
   nullable = false
 }
+
+variable "bastion_keyname" {
+  description = "name of keypair for bastion login. Must be created in target region"
+  type        = string
+  nullable    = false
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,14 +1,17 @@
 variable "prefix" {
-  type    = string
-  default = "bsky"
+  type     = string
+  default  = "bsky"
+  nullable = false
 }
 
 variable "project" {
-  type    = string
-  default = "BlueSky"
+  type     = string
+  default  = "BlueSky"
+  nullable = false
 }
 
 variable "region" {
-  type    = string
-  default = "us-east-1"
+  type     = string
+  default  = "us-east-1"
+  nullable = false
 }


### PR DESCRIPTION
This PR:
- Implements a private ec2 instance in a private subnet
- Fixes usage of variables:
  - vars were not reference in `main.tf`
  - bad script not ignoring comments in env vars causing overwrite of tf variables with blanks
- Adds a single bastion host in public subnet A.