### PR TITLE
impld count meta for multiple resources

### DIFF
--- a/terraform/bastion.tf
+++ b/terraform/bastion.tf
@@ -40,7 +40,7 @@ resource "aws_instance" "bastion" {
   instance_type = "t2.nano"
 
   key_name  = var.bastion_keyname
-  subnet_id = aws_subnet.public_a.id
+  subnet_id = aws_subnet.public[0].id
   vpc_security_group_ids = [
     aws_security_group.bastion.id
   ]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,12 +19,16 @@ provider "aws" {
 
 
 locals {
-  prefix  = var.prefix
-  project = var.project
-  region  = var.region
-  pubkey  = var.bastion_keyname
-  own_ip  = data.http.ip.response_body
-
+  prefix              = var.prefix
+  project             = var.project
+  region              = var.region
+  pubkey              = var.bastion_keyname
+  own_ip              = data.http.ip.response_body
+  public_cidrs        = var.public_subnet_cidr_blocks
+  private_cidrs       = var.private_subnet_cidr_blocks
+  zones               = var.az_suffixes
+  num_public_subnets  = length(var.public_subnet_cidr_blocks)
+  num_private_subnets = length(var.private_subnet_cidr_blocks)
   common_tags = {
     Project   = var.project
     ManagedBy = "Terraform"

--- a/terraform/priv-server-a.tf
+++ b/terraform/priv-server-a.tf
@@ -28,7 +28,7 @@ resource "aws_security_group" "allow_ssh" {
 }
 
 resource "aws_network_interface" "ubuntu_nic_a" {
-  subnet_id       = aws_subnet.private_a.id
+  subnet_id       = aws_subnet.private[0].id
   security_groups = [aws_security_group.allow_ssh.id]
 
   tags = merge(

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -21,3 +21,21 @@ variable "bastion_keyname" {
   type        = string
   nullable    = false
 }
+
+variable "public_subnet_cidr_blocks" {
+  description = "Available cidr blocks for public subnets."
+  type        = list(string)
+  default     = ["10.1.1.0/24", "10.1.2.0/24"]
+}
+
+variable "private_subnet_cidr_blocks" {
+  description = "Available cidr blocks for private subnets."
+  type        = list(string)
+  default     = ["10.1.10.0/24", "10.1.11.0/24"]
+}
+
+variable "az_suffixes" {
+  description = "Available Zone suffixes (a, b, etc) for use with resources."
+  type        = list(string)
+  default     = ["a", "b"]
+}


### PR DESCRIPTION
Changed implementation to combine similar resources created more than once and to propagate that to name tags as well. Yields indexed resources per example below:
```
 # aws_eip.public[1] will be created
  + resource "aws_eip" "public" {
      + allocation_id        = (known after apply)

 ... <snip> ...

      + tags_all             = {
          + "ManagedBy" = "Terraform"
          + "Name"      = "bsky_public_b"
          + "Project"   = "BlueSky"
        }
      + vpc                  = (known after apply)
    }
    ```